### PR TITLE
Universal hash (WIP)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 **/imagenet
 *.sh
 *.pth
+*.pt
 /old/weights/
 /datasets/
 /dataset/
@@ -19,6 +20,12 @@
 /node_package/node_modules
 /node_package/package-lock.json
 /node_package/models/
+/node_package/examples/models/
 dinov2_vitb14_reg_512bit_dynamic.onnx
 dinov2_vits14_reg_96bit_dynamic.onnx
 .venv/
+onnx/
+.DS_Store
+
+pretrained-models/*
+params/*

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 /node_package/models/
 dinov2_vitb14_reg_512bit_dynamic.onnx
 dinov2_vits14_reg_96bit_dynamic.onnx
+.venv/

--- a/hashes/universal_hash.py
+++ b/hashes/universal_hash.py
@@ -1,0 +1,83 @@
+import torch
+import numpy as np
+from torchvision import transforms
+from PIL import Image
+from typing import Union, List
+import sys
+import os
+
+class UniversalHash:
+    def __init__(self, pca_dims=None, base_name="dino_mnv2_sslight_traced", device="cuda"):
+        self.device = device
+
+        means = np.load(f'./hashes/pca2/{base_name}_means.npy')
+        self.means_torch = torch.from_numpy(means).float()
+
+        components = np.load(f'./hashes/pca2/{base_name}_PCA.npy')
+        self.components_torch = torch.from_numpy(components).float()
+
+        if pca_dims is None:
+            pca_dims = components.shape[1]
+
+        self.pca_dims = pca_dims
+        self.base_name = base_name
+        path = os.path.join("./hashes/pretrained_models", base_name + ".pt")
+
+        self.model = torch.jit.load(path)
+        self.model.eval()
+
+    def hash(
+        self,
+        image_arrays: Union[np.ndarray, List[Image.Image], torch.Tensor],
+        ) -> torch.Tensor:
+
+        if isinstance(image_arrays, np.ndarray):
+            image_arrays = torch.from_numpy(image_arrays)
+        if isinstance(image_arrays[0], Image.Image):
+            image_arrays = torch.stack([preprocess(im) for im in image_arrays])
+        if isinstance(image_arrays[0], str):
+            image_arrays = torch.stack([preprocess(Image.open(im)) for im in image_arrays])
+
+        with torch.no_grad():
+            if (self.device == "cuda"):
+                image_arrays = normalize(image_arrays)
+            else:
+                image_arrays = normalize(image_arrays.cpu())
+            
+            outs = self.model(image_arrays) - self.means_torch
+            
+            outs = outs @ self.components_torch
+
+            outs = outs[:, :self.pca_dims] >= 0
+
+        del image_arrays
+
+        return outs
+
+
+normalize = transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
+preprocess = transforms.Compose([
+    transforms.Resize((224, 224)),
+    transforms.ToTensor(),
+])
+
+class Hash:
+    def __init__(self, tensor: torch.Tensor):
+        self.tensor = tensor.cpu()
+        self.string = ''.join(str(int(x)) for x in self.tensor)
+        self.hex = hex(int(self.string, 2))
+        self.array = self.tensor.numpy()
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python universal_hash.py <image_path>")
+        sys.exit(1)
+
+    image_path = sys.argv[1]
+    image = Image.open(image_path)
+    universal_hash = UniversalHash(pca_dims=96, base_name="dino_mnv2_sslight_traced", device="cpu").hash
+    hash_tensor = universal_hash([image])[0]
+
+    hash = Hash(hash_tensor)
+    print("Perceptual hash:", hash.hex)
+

--- a/model_to_onnx_universal.py
+++ b/model_to_onnx_universal.py
@@ -24,7 +24,7 @@ def download_params(model_name):
     os.makedirs("./params", exist_ok=True)
     print(f"Downloading params for model {model_name}")
 
-    PCA_path = hf_hub_download(
+    hf_hub_download(
         repo_id="dantehrani/proteus-models",
         filename=f"params/{model_name}_PCA.npy",
         revision="main",
@@ -32,9 +32,8 @@ def download_params(model_name):
         local_dir="./",
     )
 
-    print(f"PCA downloaded to {PCA_path}")
 
-    means_path = hf_hub_download(
+    hf_hub_download(
         repo_id="dantehrani/proteus-models",
         filename=f"params/{model_name}_means.npy",
         revision="main",
@@ -42,7 +41,8 @@ def download_params(model_name):
         local_dir="./",
     )
 
-    print(f"Means downloaded to {means_path}")
+    print(f"Params downloaded for model {model_name}")
+
 
 # Export a model to ONNX to the onnx folder
 def export_model(model_name):
@@ -62,8 +62,6 @@ def export_model(model_name):
     components = components.T
     components_torch = torch.from_numpy(components).float()
 
-    #! Commented out because this causes the export to fail
-    """
     # integrate linear component to mimic PCA
     linear = nn.Linear(components_torch.shape[0], components_torch.shape[1])
     linear.weight.data = nn.parameter.Parameter(components_torch.T)
@@ -73,7 +71,8 @@ def export_model(model_name):
         model,
         linear
     )
-    """
+
+    scripted_model = torch.jit.script(model)
 
     batch_size = 42  # can be set to anything
     example = torch.rand(batch_size, 3, 224, 224)
@@ -86,7 +85,7 @@ def export_model(model_name):
     }
 
     torch.onnx.export(
-        model,
+        scripted_model,
         (example,),
         f"./onnx/{model_name}.onnx",
         opset_version=17,
@@ -101,6 +100,8 @@ def export_model(model_name):
 
 
 if __name__ == "__main__":
+    os.makedirs("./onnx", exist_ok=True)
+    
     # Get the list of models from the huggingface repo
     files = list_repo_files("dantehrani/proteus-models", repo_type="model")
 

--- a/model_to_onnx_universal.py
+++ b/model_to_onnx_universal.py
@@ -43,7 +43,6 @@ def download_params(model_name):
 
     print(f"Params downloaded for model {model_name}")
 
-
 # Export a model to ONNX to the onnx folder
 def export_model(model_name):
     print(f"Exporting model {model_name} to ONNX")
@@ -54,12 +53,10 @@ def export_model(model_name):
     # Load the model
     model = torch.jit.load(f"./pretrained-models/{model_name}.pt", map_location="cpu").eval()
     
-    
     means = np.load(f'./params/{model_name}_means.npy')
     means_torch = torch.from_numpy(means).float()
     
     components = np.load(f'./params/{model_name}_PCA.npy').T
-    components = components.T
     components_torch = torch.from_numpy(components).float()
 
     # integrate linear component to mimic PCA
@@ -67,17 +64,11 @@ def export_model(model_name):
     linear.weight.data = nn.parameter.Parameter(components_torch.T)
     linear.bias.data = nn.parameter.Parameter(-means_torch@components_torch)
 
-    model = nn.Sequential(
-        model,
-        linear
-    )
-
+    model = nn.Sequential(model, linear)
     scripted_model = torch.jit.script(model)
 
     batch_size = 42  # can be set to anything
     example = torch.rand(batch_size, 3, 224, 224)
-
-    example = torch.rand(1, 3, 224, 224)  # use batch=1 for export; we’ll make it dynamic
 
     dynamic_axes = {
         'input': {0: 'batch_size'},
@@ -96,7 +87,6 @@ def export_model(model_name):
     )    
 
     print(f"Model {model_name} exported to ONNX\n")
-
 
 
 if __name__ == "__main__":

--- a/model_to_onnx_universal.py
+++ b/model_to_onnx_universal.py
@@ -1,0 +1,115 @@
+import torch
+import numpy as np
+import torch.nn as nn
+import os
+from huggingface_hub import hf_hub_download, list_repo_files
+
+# Download the model weights from the huggingface repo
+def download_model(model_name):
+    os.makedirs("./pretrained-models", exist_ok=True)
+    print(f"Downloading model {model_name}")
+
+    model_path = hf_hub_download(
+        repo_id="dantehrani/proteus-models",
+        filename=f"pretrained-models/{model_name}.pt",
+        revision="main",
+        repo_type="model",
+        local_dir="./"
+    )
+
+    print(f"Model downloaded to {model_path}")
+
+# Download the model params from the huggingface repo
+def download_params(model_name):
+    os.makedirs("./params", exist_ok=True)
+    print(f"Downloading params for model {model_name}")
+
+    PCA_path = hf_hub_download(
+        repo_id="dantehrani/proteus-models",
+        filename=f"params/{model_name}_PCA.npy",
+        revision="main",
+        repo_type="model",
+        local_dir="./",
+    )
+
+    print(f"PCA downloaded to {PCA_path}")
+
+    means_path = hf_hub_download(
+        repo_id="dantehrani/proteus-models",
+        filename=f"params/{model_name}_means.npy",
+        revision="main",
+        repo_type="model",
+        local_dir="./",
+    )
+
+    print(f"Means downloaded to {means_path}")
+
+# Export a model to ONNX to the onnx folder
+def export_model(model_name):
+    print(f"Exporting model {model_name} to ONNX")
+
+    download_model(model_name)
+    download_params(model_name)
+
+    # Load the model
+    model = torch.jit.load(f"./pretrained-models/{model_name}.pt", map_location="cpu").eval()
+    
+    
+    means = np.load(f'./params/{model_name}_means.npy')
+    means_torch = torch.from_numpy(means).float()
+    
+    components = np.load(f'./params/{model_name}_PCA.npy').T
+    components = components.T
+    components_torch = torch.from_numpy(components).float()
+
+    #! Commented out because this causes the export to fail
+    """
+    # integrate linear component to mimic PCA
+    linear = nn.Linear(components_torch.shape[0], components_torch.shape[1])
+    linear.weight.data = nn.parameter.Parameter(components_torch.T)
+    linear.bias.data = nn.parameter.Parameter(-means_torch@components_torch)
+
+    model = nn.Sequential(
+        model,
+        linear
+    )
+    """
+
+    batch_size = 42  # can be set to anything
+    example = torch.rand(batch_size, 3, 224, 224)
+
+    example = torch.rand(1, 3, 224, 224)  # use batch=1 for export; we’ll make it dynamic
+
+    dynamic_axes = {
+        'input': {0: 'batch_size'},
+        'output': {0: 'batch_size'}
+    }
+
+    torch.onnx.export(
+        model,
+        (example,),
+        f"./onnx/{model_name}.onnx",
+        opset_version=17,
+        dynamic_axes=dynamic_axes,
+        input_names=['input'],
+        output_names=['output'],
+        do_constant_folding=True,
+    )    
+
+    print(f"Model {model_name} exported to ONNX\n")
+
+
+
+if __name__ == "__main__":
+    # Get the list of models from the huggingface repo
+    files = list_repo_files("dantehrani/proteus-models", repo_type="model")
+
+    model_files = [f for f in files if f.startswith("pretrained-models")]
+    model_names = [f.split("/")[1].split(".")[0] for f in model_files]
+
+    # Export the models to ONNX one by one
+    for model_name in model_names:
+        try:
+            export_model(model_name)
+        except Exception as e:
+            print(f"Error exporting model {model_name}: {e}\n")

--- a/node_package/examples/example.js
+++ b/node_package/examples/example.js
@@ -1,15 +1,18 @@
 const { downloadModel, loadModel, hash } = require('@proteus-labs/dinohash');
 const path = require('path');
+const { getModelUrl } = require('../src/utils');
 
 async function main() {
-  const modelUrl = 'https://huggingface.co/backslashh/DINOHash/resolve/main/dinov2_vits14_reg_96bit.onnx';
-  const modelPath = path.join(__dirname, './models/dinov2_vits14_reg_96bit_dynamic.onnx');
+  const modelName = "ResNet-101-Efficient-B0_scripted" // Specify the model to use
+  const modelUrl = getModelUrl(modelName);　
+  const modelPath = path.join(__dirname, `./models/${modelName}.onnx`);
   const imagePaths = [path.join(__dirname, 'test.png'), path.join(__dirname, 'test.png')];
-  
+
   await downloadModel(modelUrl, modelPath);
   const session = await loadModel(modelPath, device='cpu'); // can use 'cuda' for GPU inference if you have the right setup
   const results = await hash(session, imagePaths);
-  console.log(results);
+
+  console.log(results[0]);
 }
 
 main();

--- a/node_package/index.js
+++ b/node_package/index.js
@@ -1,9 +1,12 @@
 const downloader = require('./src/downloader');
 const model = require('./src/model');
 const inference = require('./src/inference');
+const utils = require("./src/utils");
 
 module.exports = {
   downloadModel: downloader.downloadModel,
   loadModel: model.loadModel,
-  hash: inference.hash
+  hash: inference.hash,
+  getModelUrl: utils.getModelUrl,
+  getModels: utils.getModels
 };

--- a/node_package/src/utils.js
+++ b/node_package/src/utils.js
@@ -23,7 +23,10 @@ const MODEL_URLS = {
   "dino_mnv2_sslight_traced": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/dino_mnv2_sslight_traced.onnx",
   "dino_vitt16_sslight_traced": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/dino_vitt16_sslight_traced.onnx",
   "moco_mnv2_sslight_traced": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/moco_mnv2_sslight_traced.onnx",
-  "swav_mnv2_sslight_traced": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/swav_mnv2_sslight_traced.onnx"
+  "swav_mnv2_sslight_traced": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/swav_mnv2_sslight_traced.onnx",
+  "ResNet-101–Efficient-B0_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-101–Efficient-B0_scripted.onnx",
+  "dino_r18_sslight_scripted":"https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/dino_r18_sslight_scripted.onnx",
+  "dino_r34_sslight_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/dino_r34_sslight_scripted.onnx"
 }
 
 const getModels = () => {

--- a/node_package/src/utils.js
+++ b/node_package/src/utils.js
@@ -1,31 +1,31 @@
 
 const MODEL_URLS = {
-  "ResNet-101-Efficient-B0_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-101–Efficient-B0_scripted.onnx",
-  "ResNet-101–Efficient-B1_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-101–Efficient-B1_scripted.onnx",
-  "ResNet-101–MobileNet-v3_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-101–MobileNet-v3_scripted.onnx",
-  "ResNet-101–ResNet-18_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-101–ResNet-18_scripted.onnx",
-  "ResNet-101–ResNet-34_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-101–ResNet-34_scripted.onnx",
-  "ResNet-152–Efficient-B0_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-152–Efficient-B0_scripted.onnx",
-  "ResNet-152–Efficient-B1_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-152–Efficient-B1_scripted.onnx",
-  "ResNet-152–MobileNet-v3_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-152–MobileNet-v3_scripted.onnx",
-  "ResNet-152–ResNet-18_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-152–ResNet-18_scripted.onnx",
-  "ResNet-152–ResNet-34_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-152–ResNet-34_scripted.onnx",
-  "ResNet-50*2–Efficient-B0_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-50*2–Efficient-B0_scripted.onnx",
-  "ResNet-50*2–Efficient-B1_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-50*2–Efficient-B1_scripted.onnx",
-  "ResNet-50*2–MobileNet-v3_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-50*2–MobileNet-v3_scripted.onnx",
-  "ResNet-50*2–ResNet-18_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-50*2–ResNet-18_scripted.onnx",
-  "ResNet-50*2–ResNet-34_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-50*2–ResNet-34_scripted.onnx",
-  "ResNet-50–Efficient-B0_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-50–Efficient-B0_scripted.onnx",
-  "ResNet-50–Efficient-B1_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-50–Efficient-B1_scripted.onnx",
-  "ResNet-50–MobileNet-v3_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-50–MobileNet-v3_scripted.onnx",
-  "ResNet-50–ResNet-18_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-50–ResNet-18_scripted.onnx",
-  "ResNet-50–ResNet-34_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-50–ResNet-34_scripted.onnx",
+  "ResNet-101-Efficient-B0_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-101-Efficient-B0_scripted.onnx",
+  "ResNet-101-Efficient-B1_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-101-Efficient-B1_scripted.onnx",
+  "ResNet-101-MobileNet-v3_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-101-MobileNet-v3_scripted.onnx",
+  "ResNet-101-ResNet-18_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-101-ResNet-18_scripted.onnx",
+  "ResNet-101-ResNet-34_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-101-ResNet-34_scripted.onnx",
+  "ResNet-152-Efficient-B0_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-152-Efficient-B0_scripted.onnx",
+  "ResNet-152-Efficient-B1_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-152-Efficient-B1_scripted.onnx",
+  "ResNet-152-MobileNet-v3_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-152-MobileNet-v3_scripted.onnx",
+  "ResNet-152-ResNet-18_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-152-ResNet-18_scripted.onnx",
+  "ResNet-152-ResNet-34_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-152-ResNet-34_scripted.onnx",
+  "ResNet-50*2-Efficient-B0_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-50*2-Efficient-B0_scripted.onnx",
+  "ResNet-50*2-Efficient-B1_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-50*2-Efficient-B1_scripted.onnx",
+  "ResNet-50*2-MobileNet-v3_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-50*2-MobileNet-v3_scripted.onnx",
+  "ResNet-50*2-ResNet-18_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-50*2-ResNet-18_scripted.onnx",
+  "ResNet-50*2-ResNet-34_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-50*2-ResNet-34_scripted.onnx",
+  "ResNet-50-Efficient-B0_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-50-Efficient-B0_scripted.onnx",
+  "ResNet-50-Efficient-B1_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-50-Efficient-B1_scripted.onnx",
+  "ResNet-50-MobileNet-v3_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-50-MobileNet-v3_scripted.onnx",
+  "ResNet-50-ResNet-18_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-50-ResNet-18_scripted.onnx",
+  "ResNet-50-ResNet-34_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-50-ResNet-34_scripted.onnx",
   "dino_mnv2_sslight_traced": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/dino_mnv2_sslight_traced.onnx",
   "dino_vitt16_sslight_traced": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/dino_vitt16_sslight_traced.onnx",
   "moco_mnv2_sslight_traced": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/moco_mnv2_sslight_traced.onnx",
   "swav_mnv2_sslight_traced": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/swav_mnv2_sslight_traced.onnx",
-  "ResNet-101–Efficient-B0_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-101–Efficient-B0_scripted.onnx",
-  "dino_r18_sslight_scripted":"https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/dino_r18_sslight_scripted.onnx",
+  "ResNet-101-Efficient-B0_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-101-Efficient-B0_scripted.onnx",
+  "dino_r18_sslight_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/dino_r18_sslight_scripted.onnx",
   "dino_r34_sslight_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/dino_r34_sslight_scripted.onnx"
 }
 
@@ -34,11 +34,11 @@ const getModels = () => {
 }
 
 const getModelUrl = (modelName) => {
-    if (Object.keys(MODEL_URLS).includes(!modelName)) {
-        throw new Error(`Model ${modelName} not found`)
-    }
+  if (Object.keys(MODEL_URLS).includes(!modelName)) {
+    throw new Error(`Model ${modelName} not found`)
+  }
 
-    return MODEL_URLS[modelName]
+  return MODEL_URLS[modelName]
 }
 
 

--- a/node_package/src/utils.js
+++ b/node_package/src/utils.js
@@ -1,0 +1,45 @@
+
+const MODEL_URLS = {
+  "ResNet-101-Efficient-B0_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-101–Efficient-B0_scripted.onnx",
+  "ResNet-101–Efficient-B1_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-101–Efficient-B1_scripted.onnx",
+  "ResNet-101–MobileNet-v3_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-101–MobileNet-v3_scripted.onnx",
+  "ResNet-101–ResNet-18_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-101–ResNet-18_scripted.onnx",
+  "ResNet-101–ResNet-34_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-101–ResNet-34_scripted.onnx",
+  "ResNet-152–Efficient-B0_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-152–Efficient-B0_scripted.onnx",
+  "ResNet-152–Efficient-B1_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-152–Efficient-B1_scripted.onnx",
+  "ResNet-152–MobileNet-v3_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-152–MobileNet-v3_scripted.onnx",
+  "ResNet-152–ResNet-18_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-152–ResNet-18_scripted.onnx",
+  "ResNet-152–ResNet-34_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-152–ResNet-34_scripted.onnx",
+  "ResNet-50*2–Efficient-B0_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-50*2–Efficient-B0_scripted.onnx",
+  "ResNet-50*2–Efficient-B1_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-50*2–Efficient-B1_scripted.onnx",
+  "ResNet-50*2–MobileNet-v3_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-50*2–MobileNet-v3_scripted.onnx",
+  "ResNet-50*2–ResNet-18_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-50*2–ResNet-18_scripted.onnx",
+  "ResNet-50*2–ResNet-34_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-50*2–ResNet-34_scripted.onnx",
+  "ResNet-50–Efficient-B0_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-50–Efficient-B0_scripted.onnx",
+  "ResNet-50–Efficient-B1_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-50–Efficient-B1_scripted.onnx",
+  "ResNet-50–MobileNet-v3_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-50–MobileNet-v3_scripted.onnx",
+  "ResNet-50–ResNet-18_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-50–ResNet-18_scripted.onnx",
+  "ResNet-50–ResNet-34_scripted": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/ResNet-50–ResNet-34_scripted.onnx",
+  "dino_mnv2_sslight_traced": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/dino_mnv2_sslight_traced.onnx",
+  "dino_vitt16_sslight_traced": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/dino_vitt16_sslight_traced.onnx",
+  "moco_mnv2_sslight_traced": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/moco_mnv2_sslight_traced.onnx",
+  "swav_mnv2_sslight_traced": "https://huggingface.co/dantehrani/proteus-models/resolve/main/onnx/swav_mnv2_sslight_traced.onnx"
+}
+
+const getModels = () => {
+  return Object.keys(MODEL_URLS)
+}
+
+const getModelUrl = (modelName) => {
+    if (Object.keys(MODEL_URLS).includes(!modelName)) {
+        throw new Error(`Model ${modelName} not found`)
+    }
+
+    return MODEL_URLS[modelName]
+}
+
+
+module.exports = {
+  getModels,
+  getModelUrl
+}


### PR DESCRIPTION
Updates
- Uploaded the .pt files and the .npy to [my huggingface repo](https://huggingface.co/dantehrani/proteus-models/tree/main) because github didn’t let me push all of them to the repo. The [model_to_onnx_universal.py](https://github.com/proteus-photos/dinohash-perceptual-hash/blob/dan/universal-hash/model_to_onnx_universal.py) script downloads them and export onnx files
- In [model_to_onnx_universal.py](https://github.com/proteus-photos/dinohash-perceptual-hash/blob/dan/universal-hash/model_to_onnx_universal.py), couldn’t figure out how to add the linear layer and make the export succeed. I tried different configs but nothing worked so far. It works without the linear layer so I exported without the linear layer for now. (just to test the e2e flow)
- Uploaded the broken models (without the linear layer) to [my huggingface repo](https://huggingface.co/dantehrani/proteus-models/tree/main) and tested that it can be fetched & runs from the node.js script (although broken)
- Updated the npm library code to make it work with different models

Questions
- Do you have any idea how to make the export work properly?