### PR TITLE
Update axios dependency version to 1.12.2

### DIFF
--- a/node_package/package.json
+++ b/node_package/package.json
@@ -16,7 +16,7 @@
     "license": "MIT",
     "dependencies": {
         "@proteus-labs/dinohash": "^1.4.0",
-        "axios": "1.8.4",
+        "axios": "1.12.2",
         "fs-extra": "11.3.0",
         "jimp": "1.6.0",
         "onnxruntime-node": "1.21.0",


### PR DESCRIPTION
Currently `Axios` provides high severity vulnerability, when using lower version than 1.12.
